### PR TITLE
ISSUE対応　ISSUE　NetCommons3/NetCommons3/#129

### DIFF
--- a/Controller/Component/VisualCaptchaComponent.php
+++ b/Controller/Component/VisualCaptchaComponent.php
@@ -164,16 +164,20 @@ class VisualCaptchaComponent extends Component {
 		// 画像認証リソースファイルへのパス
 		$this->assetPath = App::pluginPath('VisualCaptcha') . 'Resource' . DS . 'visual_captcha';
 
-		// 記録されている正解データを保持
-		$this->imageField = $this->controller->Session->read('visualcaptcha.frontendData.imageFieldName');
-		$this->audioField = $this->controller->Session->read('visualcaptcha.frontendData.audioFieldName');
+		// フレームID別に記録されている正解データを保持
+		$frameId = Hash::get($this->controller->request->query, 'frame_id');
+		$session = new Session('visual_captcha_' . $frameId);
+		$frontendData = $session->get('frontendData');
+		$this->imageField = $frontendData['imageFieldName'];
+		$this->audioField = $frontendData['audioFieldName'];
 		// セキュリティコンポーネントを使用されている場合は
 		// 画像認証フィールドをUnlockにしておく
 		if (array_key_exists('Security', $this->controller->components)) {
 			if ($this->imageField && $this->audioField) {
 				$this->controller->Security->unlockedFields = array(
 					$this->imageField,
-					$this->audioField
+					$this->audioField,
+					'frame_id'
 				);
 			}
 		}
@@ -234,7 +238,7 @@ class VisualCaptchaComponent extends Component {
  */
 	public function check() {
 		$reqData = $this->controller->request->data;
-		$session = new Session();
+		$session = new Session('visual_captcha_' . (Current::read('Frame.id')));
 		$captcha = new Captcha($session, $this->assetPath);
 
 		$ret = false;
@@ -264,7 +268,7 @@ class VisualCaptchaComponent extends Component {
  * @return string
  */
 	public function generate($count = 5) {
-		$session = new Session();
+		$session = new Session('visual_captcha_' . (Current::read('Frame.id')));
 		$lang = Configure::read('Config.language');
 		$imageJsonPath = $this->assetPath . DS . $lang . DS . 'images.json';
 		$audioJsonPath = $this->assetPath . DS . $lang . DS . 'audios.json';
@@ -294,7 +298,7 @@ class VisualCaptchaComponent extends Component {
  * @return string
  */
 	public function image($index) {
-		$session = new Session();
+		$session = new Session('visual_captcha_' . (Current::read('Frame.id')));
 		$captcha = new Captcha($session, $this->assetPath);
 
 		return $captcha->streamImage(array(), $index, 0);
@@ -306,7 +310,7 @@ class VisualCaptchaComponent extends Component {
  * @return streaming data
  */
 	public function audio() {
-		$session = new Session();
+		$session = new Session('visual_captcha_' . (Current::read('Frame.id')));
 		$captcha = new Captcha($session, $this->assetPath);
 		return $captcha->streamAudio(array(), 'mp3');
 	}

--- a/Test/Case/Controller/VisualCaptchaController/ViewTest.php
+++ b/Test/Case/Controller/VisualCaptchaController/ViewTest.php
@@ -112,6 +112,17 @@ class VisualCaptchaControllerViewTest extends NetCommonsControllerTestCase {
  * @return void
  */
 	public function testCaptchaAudio() {
+		ob_start();
+		// generateさせてからでないと
+		$url = array(
+			'plugin' => 'visual_captcha',
+			'controller' => 'visual_captcha',
+			'action' => 'captcha',
+			'block_id' => 2,
+			'frame_id' => 6
+		);
+		$this->_testNcAction($url, array('method' => 'get'), null, 'view');
+		// 認証用の音声データは取り出せません
 		$url = array(
 			'plugin' => 'visual_captcha',
 			'controller' => 'visual_captcha',
@@ -119,7 +130,6 @@ class VisualCaptchaControllerViewTest extends NetCommonsControllerTestCase {
 			'block_id' => 2,
 			'frame_id' => 6
 		);
-		ob_start();
 		$this->_testNcAction($url, array('method' => 'get'), null, 'view');
 		$actual = ob_get_clean();
 		// FUJI Streaming応答のときのアサーション方法がわからない
@@ -132,6 +142,17 @@ class VisualCaptchaControllerViewTest extends NetCommonsControllerTestCase {
  * @return void
  */
 	public function testCaptchaImage() {
+		ob_start();
+		// generateさせてからでないと
+		$url = array(
+			'plugin' => 'visual_captcha',
+			'controller' => 'visual_captcha',
+			'action' => 'captcha',
+			'block_id' => 2,
+			'frame_id' => 6
+		);
+		$this->_testNcAction($url, array('method' => 'get'), null, 'view');
+		// 認証用の画像データは取り出せません
 		$url = array(
 			'plugin' => 'visual_captcha',
 			'controller' => 'visual_captcha',
@@ -139,7 +160,6 @@ class VisualCaptchaControllerViewTest extends NetCommonsControllerTestCase {
 			'block_id' => 2,
 			'frame_id' => 6
 		);
-		ob_start();
 		$this->_testNcAction($url, array('method' => 'get'), null, 'view');
 		$actual = ob_get_clean();
 		//$result = $this->_testNcAction($url, array('method' => 'get'), null, 'view');

--- a/View/Elements/visual_captcha.ctp
+++ b/View/Elements/visual_captcha.ctp
@@ -50,6 +50,8 @@
 			captcha: {
 				numberOfImages: <?php echo $imageDisplayCount; ?>,
 				url: '<?php echo $this->webroot; ?>',
+				namespaceFieldName: 'frame_id',
+				namespace: '<?php echo Current::read('Frame.id'); ?>',
 				routes: {
 					image : '<?php echo $imagePath; ?>',
 					audio : '<?php echo $audioPath; ?>',


### PR DESCRIPTION
JSファイルの方でnamespaceを指定するパラメータを設定し、
VisualCaptchaが使用しているSessionも指定されたNamespace別に保持するように変更。
なお、本来はFrameのKeyをそのNamespaceに使うべきだろうと考えたが
ComponentのInitializeで使用する都合上、URL引数から取り出せるframe_idを使うしかないと判断。